### PR TITLE
Separate formatters

### DIFF
--- a/format-orange-pi.sh
+++ b/format-orange-pi.sh
@@ -1,0 +1,96 @@
+# Working system `fdisk -l` output:
+# -------------------------------
+# Disk /dev/mmcblk0: 7.4 GiB, 7969177600 bytes, 15564800 sectors
+# Units: sectors of 1 * 512 = 512 bytes
+# Sector size (logical/physical): 512 bytes / 512 bytes
+# I/O size (minimum/optimal): 512 bytes / 512 bytes
+# Disklabel type: dos
+# Disk identifier: 0x378fc799
+#
+# Device         Boot Start      End  Sectors  Size Id Type
+# /dev/mmcblk0p1       8192 15253503 15245312  7.3G 83 Linux
+#
+
+echo_green "Formatting for Orange Pi"
+
+ROOT_PART="${device}${FIRST_PARTITION}"
+umount_if_mounted3 $ROOT_PART
+exit
+
+# mountpoints
+BOOT_MNT="$(mktemp -d --suffix=-boot)"
+ROOT_MNT="$(mktemp -d --suffix=-root)"
+echo "Using mount points: "
+echo "...Boot MNT: $BOOT_MNT"
+echo "...Root MNT: $ROOT_MNT"
+
+if [ ! $skip_format ]; then
+    echo "Creating partition table on ${device}..."
+    # to create the partitions programatically (rather than manually)
+    # we're going to simulate the manual input to fdisk
+    # The sed script strips off all the comments so that we can
+    # document what we're doing in-line with the actual commands
+    # Note that a blank line (commented as "default" will send a empty
+    # line terminated with a newline to take the fdisk default.
+    sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk ${device}
+      o # clear the in memory partition table
+      n # new partition
+      p # primary partition
+      1 # partition number 1
+        # default - start at beginning of disk
+      +110M # boot parttion
+      t # change the type (1st partition will be selected automatically)
+      c # Changed type of partition 'Linux' to 'W95 FAT32 (LBA)', mandatory for RaspberryPi
+      n # new partition
+      p # primary partition
+      2 # partion number 2
+        # default, start immediately after preceding partition
+        # default, extend partition to end of disk
+      a # make a partition bootable
+      1 # bootable partition is partition 1 -- /dev/sda1
+      p # print the in-memory partition table
+      w # write the partition table
+      q # and we're done
+EOF
+
+
+    echo "Creating filesystem on device partitions..."
+    mkfs.vfat ${BOOT_PART}
+    # ext4 filesystem is problematic on Raspbian Jessie, so
+    # stick with ext3 for now
+    mkfs.$fstype ${ROOT_PART}
+fi
+
+require_device $BOOT_PART
+require_device $ROOT_PART
+
+echo "Mounting partitions..."
+mount ${BOOT_PART} ${BOOT_MNT}
+mount ${ROOT_PART} ${ROOT_MNT}
+
+echo "Restoring files from backup... (${backup})"
+rsync  -aHAXh "${backup}/boot/" ${BOOT_MNT}
+rsync  -aHAXh --exclude "boot" "${backup}/" ${ROOT_MNT}
+mkdir -p "${ROOT_MNT}/boot"
+
+echo "Setting /etc/resolv.conf attributes to make it immutable"
+chattr +i $ROOT_MNT/etc/resolv.conf
+
+
+echo "Syncing..."
+sync
+
+echo "unmounting devices.."
+umount ${BOOT_PART}
+umount ${ROOT_PART}
+
+echo "Removing mountpoints..."
+rmdir ${BOOT_MNT}
+rmdir ${ROOT_MNT}
+
+echo_yellow "Do not forget to check the following files on target: "
+echo_yellow " * /boot/cmdline.txt"
+echo_yellow " * /etc/fstab"
+echo_yellow " * /etc/network/interfaces"
+
+echo_green "Done..."

--- a/format-orange-pi.sh
+++ b/format-orange-pi.sh
@@ -37,9 +37,8 @@ EOF
     mkfs.$fstype ${ROOT_PART}
 
     # Bootloader workaround
-    echo_yellow "WORKAROUND: Setting the UUID of root partition to old UUID"
     old_uuid=$(cat $backup/boot/armbianEnv.txt | grep rootdev | sed "s/rootdev=UUID=//")
-    echo "...changing UUID to $old_uuid"
+    echo_green "...changing UUID to $old_uuid"
     yes | tune2fs $ROOT_PART -U $old_uuid
 fi
 

--- a/format-raspberry-pi.sh
+++ b/format-raspberry-pi.sh
@@ -1,6 +1,6 @@
 # Calculate boot and rootfs partitions
-BOOT_PART="${device}${PARTITION_PREFIX}1"
-ROOT_PART="${device}${PARTITION_PREFIX}2"
+BOOT_PART="${device}${FIRST_PARTITION}"
+ROOT_PART="${device}${SECOND_PARTITION}"
 
 umount_if_mounted3 $BOOT_PART
 umount_if_mounted3 $ROOT_PART
@@ -43,7 +43,10 @@ EOF
 
 
     echo "Creating filesystem on device partitions..."
+    echo_green "...creating FAT for BOOT_PART ($BOOT_PART)"
     mkfs.vfat ${BOOT_PART}
+
+    echo_green "...creating $fstype for ROOT_PART ($ROOT_PART)"
     # ext4 filesystem is problematic on Raspbian Jessie, so
     # stick with ext3 for now
     mkfs.$fstype ${ROOT_PART}
@@ -64,7 +67,6 @@ mkdir -p "${ROOT_MNT}/boot"
 echo "Setting /etc/resolv.conf attributes to make it immutable"
 chattr +i $ROOT_MNT/etc/resolv.conf
 
-
 echo "Syncing..."
 sync
 
@@ -80,5 +82,3 @@ echo_yellow "Do not forget to check the following files on target: "
 echo_yellow " * /boot/cmdline.txt"
 echo_yellow " * /etc/fstab"
 echo_yellow " * /etc/network/interfaces"
-
-echo_green "Done..."

--- a/format-raspberry-pi.sh
+++ b/format-raspberry-pi.sh
@@ -56,26 +56,27 @@ fi
 require_device $BOOT_PART
 require_device $ROOT_PART
 
-echo "Mounting partitions..."
+echo_green "Restoring files from backup to device..."
+echo "...mounting partitions"
 mount ${BOOT_PART} ${BOOT_MNT}
 mount ${ROOT_PART} ${ROOT_MNT}
 
-echo "Restoring files from backup... (${backup})"
+echo "...restoring files from backup (.${backup#$PWD}) (this may take a while...)"
 rsync  -aHAXh "${backup}/boot/" ${BOOT_MNT}
 rsync  -aHAXh --exclude "boot" "${backup}/" ${ROOT_MNT}
 mkdir -p "${ROOT_MNT}/boot"
 
-echo "Setting /etc/resolv.conf attributes to make it immutable"
+echo "...setting /etc/resolv.conf attributes to make it immutable"
 chattr +i $ROOT_MNT/etc/resolv.conf
 
-echo "Syncing..."
+echo "...syncing"
 sync
 
-echo "unmounting devices.."
+echo "...unmounting devices"
 umount ${BOOT_PART}
 umount ${ROOT_PART}
 
-echo "Removing mountpoints..."
+echo "...removing mountpoints"
 rmdir ${BOOT_MNT}
 rmdir ${ROOT_MNT}
 

--- a/format-raspberry-pi.sh
+++ b/format-raspberry-pi.sh
@@ -46,9 +46,10 @@ EOF
     echo_green "...creating FAT for BOOT_PART ($BOOT_PART)"
     mkfs.vfat ${BOOT_PART}
 
-    echo_green "...creating $fstype for ROOT_PART ($ROOT_PART)"
     # ext4 filesystem is problematic on Raspbian Jessie, so
     # stick with ext3 for now
+    fstype="ext3"
+    echo_green "...creating $fstype for ROOT_PART ($ROOT_PART)"
     mkfs.$fstype ${ROOT_PART}
 fi
 

--- a/format-raspberry-pi.sh
+++ b/format-raspberry-pi.sh
@@ -1,0 +1,84 @@
+# Calculate boot and rootfs partitions
+BOOT_PART="${device}${PARTITION_PREFIX}1"
+ROOT_PART="${device}${PARTITION_PREFIX}2"
+
+umount_if_mounted3 $BOOT_PART
+umount_if_mounted3 $ROOT_PART
+
+# mountpoints
+BOOT_MNT="$(mktemp -d --suffix=-boot)"
+ROOT_MNT="$(mktemp -d --suffix=-root)"
+echo "Using mount points: "
+echo "...Boot MNT: $BOOT_MNT"
+echo "...Root MNT: $ROOT_MNT"
+
+if [ ! $skip_format ]; then
+    echo "Creating partition table on ${device}..."
+    # to create the partitions programatically (rather than manually)
+    # we're going to simulate the manual input to fdisk
+    # The sed script strips off all the comments so that we can
+    # document what we're doing in-line with the actual commands
+    # Note that a blank line (commented as "default" will send a empty
+    # line terminated with a newline to take the fdisk default.
+    sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk ${device}
+      o # clear the in memory partition table
+      n # new partition
+      p # primary partition
+      1 # partition number 1
+        # default - start at beginning of disk
+      +110M # boot parttion
+      t # change the type (1st partition will be selected automatically)
+      c # Changed type of partition 'Linux' to 'W95 FAT32 (LBA)', mandatory for RaspberryPi
+      n # new partition
+      p # primary partition
+      2 # partion number 2
+        # default, start immediately after preceding partition
+        # default, extend partition to end of disk
+      a # make a partition bootable
+      1 # bootable partition is partition 1 -- /dev/sda1
+      p # print the in-memory partition table
+      w # write the partition table
+      q # and we're done
+EOF
+
+
+    echo "Creating filesystem on device partitions..."
+    mkfs.vfat ${BOOT_PART}
+    # ext4 filesystem is problematic on Raspbian Jessie, so
+    # stick with ext3 for now
+    mkfs.$fstype ${ROOT_PART}
+fi
+
+require_device $BOOT_PART
+require_device $ROOT_PART
+
+echo "Mounting partitions..."
+mount ${BOOT_PART} ${BOOT_MNT}
+mount ${ROOT_PART} ${ROOT_MNT}
+
+echo "Restoring files from backup... (${backup})"
+rsync  -aHAXh "${backup}/boot/" ${BOOT_MNT}
+rsync  -aHAXh --exclude "boot" "${backup}/" ${ROOT_MNT}
+mkdir -p "${ROOT_MNT}/boot"
+
+echo "Setting /etc/resolv.conf attributes to make it immutable"
+chattr +i $ROOT_MNT/etc/resolv.conf
+
+
+echo "Syncing..."
+sync
+
+echo "unmounting devices.."
+umount ${BOOT_PART}
+umount ${ROOT_PART}
+
+echo "Removing mountpoints..."
+rmdir ${BOOT_MNT}
+rmdir ${ROOT_MNT}
+
+echo_yellow "Do not forget to check the following files on target: "
+echo_yellow " * /boot/cmdline.txt"
+echo_yellow " * /etc/fstab"
+echo_yellow " * /etc/network/interfaces"
+
+echo_green "Done..."

--- a/produce-bootable-disk
+++ b/produce-bootable-disk
@@ -117,14 +117,14 @@ if [ "$fstype" == "" ]; then
     #echo_yellow "Using default $fstype type. "
 fi
 
-hardware="format-$hardware.sh"
-if [[ ! -f "$DIR/$hardware" ]]; then
+restore_script="$DIR/format-$hardware.sh"
+if [[ ! -f "$restore_script" ]]; then
     formatters=$(ls $DIR/format-*.sh | xargs -n 1 basename | sed "s/format-\(.*\)\.sh/\1/")
     echo_yellow "ERROR: One of the hardware types must be provided: "
     for formatter in $formatters; do
         echo_yellow "ERROR: * $formatter"
     done
-    die "No such formatter found: $hardware"
+    die "No such restore script found: $hardware"
 fi
 
 if [[ ! -d $backup ]]; then
@@ -132,11 +132,16 @@ if [[ ! -d $backup ]]; then
 fi
 
 # BE ABSOLUTELY SURE THAT THE DEVICE IS NOT A CURRENTLY USED DISK!!!
+if [[ "$device" == "" ]]; then
+    die "Physical device MUST be provided."
+fi
+
 if [[ ! -b $device ]]; then
     die "Physical device $device MUST exist in the first place"
 fi
 curr_disks=$(find_disks)
 press_enter_to_continue "Unplug the disk $device and press enter to continue."
+sleep 1
 disk_diff=$(echo -n ${curr_disks#"$(find_disks)"})
 if [[ "$disk_diff" != "$device" ]]; then
     echo_err "The device you unplugged must be the device you specified before. ($disk_diff)"
@@ -146,9 +151,10 @@ else
 fi
 
 # wait for device to appear again
+sleep 1
 while [ ! -b $device ] ; do
     #echo "...waiting for $device to appear again..."
-    sleep 2
+    sleep 1
 done
 
 # Calculate partition prefix
@@ -187,9 +193,8 @@ SECOND_PARTITION="${PARTITION_PREFIX}2"
 THIRD_PARTITION="${PARTITION_PREFIX}3"
 FOURTH_PARTITION="${PARTITION_PREFIX}4"
 
-# -----------------------------------------------------------------------------
-#   All variables are set so far, include proper formatter
-# -----------------------------------------------------------------------------
+#include proper restoration script
+source $restore_script
 
-#source $DIR/format-raspberry-pi.sh
-source $DIR/format-orange-pi.sh
+# if sourced formatter didn't exit till this point, process is succeeded
+echo_green "Done..."

--- a/produce-bootable-disk
+++ b/produce-bootable-disk
@@ -23,7 +23,6 @@ safe_source $DIR/aktos-bash-lib/fs-functions.sh
 
 backup=
 device=
-fstype=
 verbose=0
 skip_format=
 
@@ -48,7 +47,6 @@ show_help () {
 
     --backup        : backup directory
     --device        : the device to format and create bootable disk
-    --fs-type       : target filesystem type (default ext3)
     --skip-format   : skip formatting target disk, only perform rsync
     --hardware      : hardware type for formatting the disk
 
@@ -86,14 +84,6 @@ while :; do
             fi
             ;;
 
-        --fs-type)       # Takes an option argument; ensure it has been specified.
-            if [ "$2" ]; then
-                fstype=$2
-                shift
-            else
-                die '"--fs-type" requires a non-empty option argument.'
-            fi
-            ;;
         -v|--verbose)
             verbose=$((verbose + 1))  # Each -v adds 1 to verbosity.
             ;;
@@ -112,11 +102,6 @@ done
 
 # check the arguments
 # -----------------------------------------------
-if [ "$fstype" == "" ]; then
-    fstype="ext3"
-    #echo_yellow "Using default $fstype type. "
-fi
-
 restore_script="$DIR/format-$hardware.sh"
 if [[ ! -f "$restore_script" ]]; then
     formatters=$(ls $DIR/format-*.sh | xargs -n 1 basename | sed "s/format-\(.*\)\.sh/\1/")
@@ -167,7 +152,6 @@ fi
 # print the summary:
 echo "Summary: "
 echo "-----------------------------------"
-echo "Using filesystem type: $fstype"
 if [ $skip_format ]; then
     echo_yellow "...will skip formatting..."
 fi

--- a/produce-bootable-disk
+++ b/produce-bootable-disk
@@ -142,15 +142,12 @@ if [[ "$disk_diff" != "$device" ]]; then
     echo_err "The device you unplugged must be the device you specified before. ($disk_diff)"
 else
     echo_green "$device seems to be the correct device."
-    press_enter_to_continue "Plug the disk again and press enter to continue."
+    echo_yellow "Plug the disk again to continue..."
 fi
 
-while :; do
-    if [[ ! -b $device ]]; then
-        echo "...waiting for $device to appear again..."
-    else
-        break
-    fi
+# wait for device to appear again
+while [ ! -b $device ] ; do
+    #echo "...waiting for $device to appear again..."
     sleep 2
 done
 
@@ -162,17 +159,17 @@ if [ "${device//[[:digit:]]/}" == "/dev/mmcblk" ]; then
 fi
 
 # print the summary:
-echo_green "Summary: "
-echo_green "-----------------------------------"
-echo_green "Using filesystem type: $fstype"
+echo "Summary: "
+echo "-----------------------------------"
+echo "Using filesystem type: $fstype"
 if [ $skip_format ]; then
     echo_yellow "...will skip formatting..."
 fi
-echo_green "Using device:"
+echo "Using device:"
 echo
 lsblk $device | indent2
 echo
-echo_green "Using backup directory: .${backup#$PWD}"
+echo "Using backup directory: .${backup#$PWD}"
 
 if prompt_yes_no "Should we really continue?"; then
     PROJECT_ROOT=$(realpath "$DIR/..")
@@ -183,6 +180,12 @@ else
 fi
 
 # end of check arguments
+
+# Semantic variables
+FIRST_PARTITION="${PARTITION_PREFIX}1"
+SECOND_PARTITION="${PARTITION_PREFIX}2"
+THIRD_PARTITION="${PARTITION_PREFIX}3"
+FOURTH_PARTITION="${PARTITION_PREFIX}4"
 
 # -----------------------------------------------------------------------------
 #   All variables are set so far, include proper formatter

--- a/produce-bootable-disk
+++ b/produce-bootable-disk
@@ -28,9 +28,11 @@ verbose=0
 skip_format=
 
 die () {
-    errcho "ERROR: "
-    errcho "ERROR: $@"
-    errcho "ERROR: "
+    if [[ "$@" ]]; then
+        errcho "ERROR: "
+        errcho "ERROR: $@"
+        errcho "ERROR: "
+    fi
     show_help
     exit 5
 }
@@ -47,7 +49,8 @@ show_help () {
     --backup        : backup directory
     --device        : the device to format and create bootable disk
     --fs-type       : target filesystem type (default ext3)
-    --skip-format   : skip formatting target disk, only rsync.
+    --skip-format   : skip formatting target disk, only perform rsync
+    --hardware      : hardware type for formatting the disk
 
 HELP
 }
@@ -74,6 +77,15 @@ while :; do
                 die '"--device" requires a non-empty option argument.'
             fi
             ;;
+        --hardware)       # Takes an option argument; ensure it has been specified.
+            if [ "$2" ]; then
+                hardware=$2
+                shift
+            else
+                die '"--hardware" requires a non-empty option argument.'
+            fi
+            ;;
+
         --fs-type)       # Takes an option argument; ensure it has been specified.
             if [ "$2" ]; then
                 fstype=$2
@@ -98,6 +110,27 @@ while :; do
     shift
 done
 
+# check the arguments
+# -----------------------------------------------
+if [ "$fstype" == "" ]; then
+    fstype="ext3"
+    #echo_yellow "Using default $fstype type. "
+fi
+
+hardware="format-$hardware.sh"
+if [[ ! -f "$DIR/$hardware" ]]; then
+    formatters=$(ls $DIR/format-*.sh | xargs -n 1 basename | sed "s/format-\(.*\)\.sh/\1/")
+    echo_yellow "ERROR: One of the hardware types must be provided: "
+    for formatter in $formatters; do
+        echo_yellow "ERROR: * $formatter"
+    done
+    die "No such formatter found: $hardware"
+fi
+
+if [[ ! -d $backup ]]; then
+    die "Backup directory must be provided. (not a dir: $backup)"
+fi
+
 # BE ABSOLUTELY SURE THAT THE DEVICE IS NOT A CURRENTLY USED DISK!!!
 if [[ ! -b $device ]]; then
     die "Physical device $device MUST exist in the first place"
@@ -116,10 +149,6 @@ while :; do
     if [[ ! -b $device ]]; then
         echo "...waiting for $device to appear again..."
     else
-        echo_green "Using device:"
-        echo
-        lsblk $device | indent2
-        echo
         break
     fi
     sleep 2
@@ -132,30 +161,27 @@ if [ "${device//[[:digit:]]/}" == "/dev/mmcblk" ]; then
     PARTITION_PREFIX="p"
 fi
 
-if [ "$fstype" ]; then
-    echo_green "Using filesystem type: $fstype"
-else
-    fstype="ext3"
-    echo_yellow "Using default $fstype type. "
-fi
-
+# print the summary:
+echo_green "Summary: "
+echo_green "-----------------------------------"
+echo_green "Using filesystem type: $fstype"
 if [ $skip_format ]; then
     echo_yellow "...will skip formatting..."
 fi
-
-if [[ ! -d $backup ]]; then
-    die "Backup directory must be provided! (not a dir: $backup)"
-else
-    echo_green "Using backup directory: $backup"
-fi
-
+echo_green "Using device:"
+echo
+lsblk $device | indent2
+echo
+echo_green "Using backup directory: .${backup#$PWD}"
 
 if prompt_yes_no "Should we really continue?"; then
-    echo_yellow "Bootable device $device will be built by using $backup"
+    PROJECT_ROOT=$(realpath "$DIR/..")
+    echo_green "Building $device by using files from .${backup#$PWD}"
 else
     echo_info "Interrupted by user."
     exit 0
 fi
+
 # end of check arguments
 
 # -----------------------------------------------------------------------------

--- a/produce-bootable-disk
+++ b/produce-bootable-disk
@@ -100,7 +100,7 @@ done
 
 # BE ABSOLUTELY SURE THAT THE DEVICE IS NOT A CURRENTLY USED DISK!!!
 if [[ ! -b $device ]]; then
-    echo_err "Physical device $device MUST exist"
+    die "Physical device $device MUST exist in the first place"
 fi
 curr_disks=$(find_disks)
 press_enter_to_continue "Unplug the disk $device and press enter to continue."
@@ -112,25 +112,25 @@ else
     press_enter_to_continue "Plug the disk again and press enter to continue."
 fi
 
-if [[ ! -b $device ]]; then
-    echo_err "Physical device $device MUST exist"
-else
-    echo_green "Using device:"
-    echo
-    lsblk $device | indent2
-    echo
-fi
+while :; do
+    if [[ ! -b $device ]]; then
+        echo "...waiting for $device to appear again..."
+    else
+        echo_green "Using device:"
+        echo
+        lsblk $device | indent2
+        echo
+        break
+    fi
+    sleep 2
+done
 
 # Calculate partition prefix
-ppfx=
+PARTITION_PREFIX=
 if [ "${device//[[:digit:]]/}" == "/dev/mmcblk" ]; then
     #echo "...this is obviously an SD Card"
-    ppfx="p"
+    PARTITION_PREFIX="p"
 fi
-
-# Calculate boot and rootfs partitions
-BOOT_PART="${device}${ppfx}1"
-ROOT_PART="${device}${ppfx}2"
 
 if [ "$fstype" ]; then
     echo_green "Using filesystem type: $fstype"
@@ -142,9 +142,6 @@ fi
 if [ $skip_format ]; then
     echo_yellow "...will skip formatting..."
 fi
-
-echo_green "Using boot partition: $BOOT_PART"
-echo_green "Using rootfs partition: $ROOT_PART"
 
 if [[ ! -d $backup ]]; then
     die "Backup directory must be provided! (not a dir: $backup)"
@@ -162,86 +159,8 @@ fi
 # end of check arguments
 
 # -----------------------------------------------------------------------------
-#   All variables are set so far
+#   All variables are set so far, include proper formatter
 # -----------------------------------------------------------------------------
 
-umount_if_mounted3 $BOOT_PART
-umount_if_mounted3 $ROOT_PART
-
-# mountpoints
-BOOT_MNT="$(mktemp -d --suffix=-boot)"
-ROOT_MNT="$(mktemp -d --suffix=-root)"
-echo "Using mount points: "
-echo "...Boot MNT: $BOOT_MNT"
-echo "...Root MNT: $ROOT_MNT"
-
-if [ ! $skip_format ]; then
-    echo "Creating partition table on ${device}..."
-    # to create the partitions programatically (rather than manually)
-    # we're going to simulate the manual input to fdisk
-    # The sed script strips off all the comments so that we can
-    # document what we're doing in-line with the actual commands
-    # Note that a blank line (commented as "default" will send a empty
-    # line terminated with a newline to take the fdisk default.
-    sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk ${device}
-      o # clear the in memory partition table
-      n # new partition
-      p # primary partition
-      1 # partition number 1
-        # default - start at beginning of disk
-      +110M # boot parttion
-      t # change the type (1st partition will be selected automatically)
-      c # Changed type of partition 'Linux' to 'W95 FAT32 (LBA)', mandatory for RaspberryPi
-      n # new partition
-      p # primary partition
-      2 # partion number 2
-        # default, start immediately after preceding partition
-        # default, extend partition to end of disk
-      a # make a partition bootable
-      1 # bootable partition is partition 1 -- /dev/sda1
-      p # print the in-memory partition table
-      w # write the partition table
-      q # and we're done
-EOF
-
-
-    echo "Creating filesystem on device partitions..."
-    mkfs.vfat ${BOOT_PART}
-    # ext4 filesystem is problematic on Raspbian Jessie, so
-    # stick with ext3 for now
-    mkfs.$fstype ${ROOT_PART}
-fi
-
-require_device $BOOT_PART
-require_device $ROOT_PART
-
-echo "Mounting partitions..."
-mount ${BOOT_PART} ${BOOT_MNT}
-mount ${ROOT_PART} ${ROOT_MNT}
-
-echo "Restoring files from backup... (${backup})"
-rsync  -aHAXh "${backup}/boot/" ${BOOT_MNT}
-rsync  -aHAXh --exclude "boot" "${backup}/" ${ROOT_MNT}
-mkdir -p "${ROOT_MNT}/boot"
-
-echo "Setting /etc/resolv.conf attributes to make it immutable"
-chattr +i $ROOT_MNT/etc/resolv.conf
-
-
-echo "Syncing..."
-sync
-
-echo "unmounting devices.."
-umount ${BOOT_PART}
-umount ${ROOT_PART}
-
-echo "Removing mountpoints..."
-rmdir ${BOOT_MNT}
-rmdir ${ROOT_MNT}
-
-echo_yellow "Do not forget to check the following files on target: "
-echo_yellow " * /boot/cmdline.txt"
-echo_yellow " * /etc/fstab"
-echo_yellow " * /etc/network/interfaces"
-
-echo_green "Done..."
+#source $DIR/format-raspberry-pi.sh
+source $DIR/format-orange-pi.sh


### PR DESCRIPTION
Disk formatting scripts are separated from `produce-bootable-disk` script as different hardware will require different partitioning schema and extra operations in order to be able to prepare a proper bootable disk. 